### PR TITLE
Add support to hook OPFF onto MAIN status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ titleid = "01006A800016E000"
 crate-type = ["cdylib"]
 
 [dependencies]
-skyline = { git = "https://github.com/ultimate-research/skyline-rs.git", features = ["nro_internal"] }
+skyline = { version = "0.2" }
 # skyline_smash = { path = "../skyline-smash", features = ["weak_l2cvalue"] }
 # skyline_smash = { git = "https://github.com/blu-dev/skyline-smash.git", branch = "l2c-values", features = ["weak_l2cvalue"] }
-skyline_smash = { git = "https://github.com/ultimate-research/skyline-smash.git", features = ["weak_l2cvalue"] }
+skyline_smash = { git = "https://github.com/blu-dev/skyline-smash.git", features = ["weak_l2cvalue"] }
 nnsdk = { git = "https://github.com/ultimate-research/nnsdk-rs" }
 parking_lot = { version = "0.11.2" }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ skyline = { git = "https://github.com/ultimate-research/skyline-rs.git", feature
 # skyline_smash = { git = "https://github.com/blu-dev/skyline-smash.git", branch = "l2c-values", features = ["weak_l2cvalue"] }
 skyline_smash = { git = "https://github.com/ultimate-research/skyline-smash.git", features = ["weak_l2cvalue"] }
 nnsdk = { git = "https://github.com/ultimate-research/nnsdk-rs" }
-parking_lot = { version = "0.11.1", features = ["nightly"] }
+parking_lot = { version = "0.11.2" }
 lazy_static = "1.4.0"
 bitflags = "1.2.1"
 aarch64-decode = { git = "https://github.com/jam1garner/aarch64-decode.git", rev = "99475256e779677df456b3ec37de258d1697b97d" }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -358,7 +358,7 @@ pub extern "Rust" fn add_fighter_frame_callback(callback: FighterFrameCallback) 
         unsafe {
             SHOULD_INSTALL_FIGHTER_CB = true;
             if let Some(_) = crate::COMMON_MEMORY_INFO.as_ref() {
-                //skyline::install_hook!(fighter_frame_callbacks);
+                skyline::install_hook!(fighter_frame_callbacks);
             }
         }
     });
@@ -372,7 +372,7 @@ pub extern "Rust" fn add_weapon_frame_callback(callback: AgentFrameCallback) {
         unsafe {
             SHOULD_INSTALL_WEAPON_CB = true;
             if let Some(_) = crate::COMMON_MEMORY_INFO.as_ref() {
-                //skyline::install_hook!(weapon_frame_callbacks);
+                skyline::install_hook!(weapon_frame_callbacks);
             }
         }
     });
@@ -386,7 +386,7 @@ pub extern "Rust" fn add_agent_frame_main_callback(callback: AgentFrameCallback)
         unsafe {
             SHOULD_INSTALL_AGENT_MAIN_CB = true;
             if let Some(_) = crate::COMMON_MEMORY_INFO.as_ref() {
-                //skyline::install_hook!(agent_frame_main_callbacks);
+                skyline::install_hook!(agent_frame_main_callbacks);
             }
         }
     });

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,6 +1,7 @@
 use smash::lua2cpp::*;
 use smash::lib::{LuaConst, L2CValue, lua_const::{BATTLE_OBJECT_CATEGORY_FIGHTER, BATTLE_OBJECT_CATEGORY_WEAPON}};
 use smash::phx::Hash40;
+use smash::app::lua_bind::StatusModule;
 
 use skyline::nro::NroInfo;
 
@@ -215,8 +216,12 @@ fn weapon_frame_callbacks(weapon: &mut L2CFighterBase) -> L2CValue {
 #[skyline::hook(replace = L2CFighterBase_sys_line_status_system_control)]
 fn agent_frame_main_callbacks(agent: &mut L2CFighterBase) -> L2CValue {
     let ret = call_original!(agent);
-    for cb in AGENT_FRAME_MAIN_CALLBACKS.lock().iter() {
-        cb(agent);
+    unsafe {
+        if !StatusModule::is_changing(agent.module_accessor) {
+            for cb in AGENT_FRAME_MAIN_CALLBACKS.lock().iter() {
+                cb(agent);
+            }
+        }
     }
     ret
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -31,7 +31,7 @@ pub fn nro_load(nro_info: &NroInfo) {
     if let Some(hooks) = map.get_mut(nro_info.name) {
         for hook in hooks.iter_mut() {
             unsafe {
-                lazy_symbol_replace(nro_info.module.ModuleObject, hook.symbol.as_str(), hook.replace, hook.original.as_mut());
+                lazy_symbol_replace(nro_info.module.ModuleObject as *mut ModuleObject, hook.symbol.as_str(), hook.replace, hook.original.as_mut());
             }
         }
     }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -162,6 +162,7 @@ impl DevelopmentPlugin {
         crate::callbacks::remove_agent_resets(range);
         crate::callbacks::remove_fighter_frame_callbacks(range);
         crate::callbacks::remove_weapon_frame_callbacks(range);
+        crate::callbacks::remove_agent_frame_main_callbacks(range);
         crate::callbacks::remove_fighter_init_callbacks(range);
         crate::callbacks::remove_agent_init_callbacks(range);
         crate::acmd::remove_acmd_scripts(range);

--- a/src/nx.rs
+++ b/src/nx.rs
@@ -1,4 +1,4 @@
-
+use std::arch::asm;
 // The following code is taken from the WIP skyline rust-rewrite to assist in symbol hooking
 // the static modules
 

--- a/src/scripts.rs
+++ b/src/scripts.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use nnsdk::root::{Elf64_Sym, rtld::ModuleObject};
 
 use aarch64_decode::*;
 use skyline::nro::NroInfo;
@@ -279,7 +280,7 @@ pub fn patch_create_agent_animcmd(info: &NroInfo, category: Category) {
                 let [<$cat _share>] = format_create_agent_symbol(info.name, $shared);
                 unsafe {
                     ORIGINAL = 0 as _;
-                    lazy_symbol_replace(info.module.ModuleObject, $cat.as_str(), [<create_agent_fighter_animcmd_ $cat>] as *const _, original_opt.as_mut());
+                    lazy_symbol_replace(info.module.ModuleObject as *mut ModuleObject, $cat.as_str(), [<create_agent_fighter_animcmd_ $cat>] as *const _, original_opt.as_mut());
                     if !ORIGINAL.is_null() {
                         let mut map = $unshared_create_agents.lock();
                         map.insert(
@@ -291,7 +292,7 @@ pub fn patch_create_agent_animcmd(info: &NroInfo, category: Category) {
                         );
                     }
                     ORIGINAL = 0 as _;
-                    lazy_symbol_replace(info.module.ModuleObject, [<$cat _share>].as_str(), [<create_agent_fighter_animcmd_ $cat _share>] as *const _, original_opt.as_mut());
+                    lazy_symbol_replace(info.module.ModuleObject as *mut ModuleObject, [<$cat _share>].as_str(), [<create_agent_fighter_animcmd_ $cat _share>] as *const _, original_opt.as_mut());
                     if !ORIGINAL.is_null() {
                         let mut map = $shared_create_agents.lock();
                         map.insert(
@@ -329,7 +330,7 @@ pub fn patch_create_agent_status(info: &NroInfo) {
     let status = format_create_agent_symbol(info.name, "status_script");
     unsafe {
         ORIGINAL = 0 as _;
-        lazy_symbol_replace(info.module.ModuleObject, status.as_str(), create_agent_fighter_status_script as *const extern "C" fn(), original_opt.as_mut());
+        lazy_symbol_replace(info.module.ModuleObject as *mut ModuleObject, status.as_str(), create_agent_fighter_status_script as *const extern "C" fn(), original_opt.as_mut());
         if !ORIGINAL.is_null() {
             let mut agents = STATUS_CREATE_AGENTS.lock();
             agents.insert(


### PR DESCRIPTION
Adds `sys_line_status_system_init_replace` and `agent_frame_main_callbacks` functions, which hook `L2CFighterBase::sys_line_status_system_init` and `L2CFighterBase::sys_line_status_system_control` respectively.

This allows for an option to run OPFF either before EXEC status (current behavior) or before MAIN status (new behavior).